### PR TITLE
Add null check for waystone record in entity update

### DIFF
--- a/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlock.java
+++ b/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlock.java
@@ -86,7 +86,9 @@ public class WaystoneBlock extends BlockWithEntity implements PolymerBlock {
             return;
         if (!(placer instanceof ServerPlayerEntity player))
             return;
+
         createWaystone(pos, world, player);
+        //world.getServer().save(true, false, true);
     }
 
     public static void onRemoved(World world, BlockPos pos) {
@@ -106,8 +108,10 @@ public class WaystoneBlock extends BlockWithEntity implements PolymerBlock {
 
     @Override
     public BlockState onBreak(World world, BlockPos pos, BlockState state, PlayerEntity player) {
-        if (!world.isClient())
+        if (!world.isClient()){
             onRemoved(world, pos);
+            //world.getServer().save(true, false, true);
+        }
         return super.onBreak(world, pos, state, player);
     }
 

--- a/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
+++ b/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
@@ -50,6 +50,11 @@ public class WaystoneBlockEntity extends BlockEntity {
         boolean waystoneOwned = record != null;
         boolean shouldCreateName = record != null && waystoneEntity.nameDisplay == null;
 
+        //this works (sorta) || PLAN Z
+        if(record == null){
+            return;
+        }
+
         // Create the display itself
         if (waystoneEntity.eyeDisplay == null || shouldCreateName) {
             waystoneEntity.createHologramDisplay(world);


### PR DESCRIPTION
Added a null check for the waystone record in WaystoneBlockEntity to prevent further processing if the record is missing. Also added commented-out server save calls in WaystoneBlock for potential debugging or future use.